### PR TITLE
fix handling of directives

### DIFF
--- a/yamlpath/tests/testcases/directives.yml
+++ b/yamlpath/tests/testcases/directives.yml
@@ -1,0 +1,12 @@
+# presence of a directives block doesn't change anything.
+%YAML 1.2
+---
+testcase:
+  foo:
+    bar:
+      baz: hello!
+
+queries:
+  - query: [foo, bar, baz]
+    expected: |2-
+            baz: hello!


### PR DESCRIPTION
YAML streams can contain directive blocks, which mess up the expected structure of the document we parse. This ensures we handle them gracefully.

h/t @alex