### PR TITLE
feat: add Document::range_spanned_by_comment and Document::offset_inside_comment

### DIFF
--- a/yamlpath/Cargo.toml
+++ b/yamlpath/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
-thiserror = "2.0.11"
+thiserror = "2"
 tree-sitter = "0.25.1"
 tree-sitter-yaml = "0.7.0"
 

--- a/yamlpath/Cargo.toml
+++ b/yamlpath/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["William Woodruff <william@yossarian.net>"]
 repository = "https://github.com/woodruffw/yamlpath"
 readme = "../README.md"
 keywords = ["yaml"]
-edition = "2024"
+edition = "2021"
 license = "MIT"
 
 [dependencies]

--- a/yamlpath/src/lib.rs
+++ b/yamlpath/src/lib.rs
@@ -364,8 +364,8 @@ impl Document {
         // With this AST the spanning parent is 'parent', but the 'comment'
         // node is actually *adjacent* to 'parent' rather than enclosed in it.
 
-        let start_line = feature.location.point_span.0.0;
-        let end_line = feature.location.point_span.1.0;
+        let start_line = feature.location.point_span.0 .0;
+        let end_line = feature.location.point_span.1 .0;
 
         fn trawl<'tree>(
             node: &Node<'tree>,


### PR DESCRIPTION
These new APIs allow for checking whether a given range or offset is spanned by a comment node in a YAML document.

This is a building block for fixing https://github.com/woodruffw/zizmor/issues/569 in a general fashion.