### PR TITLE
yamlpath: handle interceding list comments correctly

### DIFF
--- a/yamlpath/tests/testcases/interceding-comment.yml
+++ b/yamlpath/tests/testcases/interceding-comment.yml
@@ -8,9 +8,18 @@ testcase:
       # comment 2
       bar: baz
 
+  many-children:
+    - # foo
+      foo: bar
+    - # bar
+      bar: baz
+
 queries:
   - query: [foo, 0, bar]
     expected: "      bar: baz"
 
   - query: [multiple, 0, bar]
+    expected: "      bar: baz"
+
+  - query: [many-children, 1, bar]
     expected: "      bar: baz"

--- a/yamlpath/tests/testcases/interceding-comment.yml
+++ b/yamlpath/tests/testcases/interceding-comment.yml
@@ -1,0 +1,16 @@
+testcase:
+  foo:
+    - # hello!
+      bar: baz
+
+  multiple:
+    - # comment 1
+      # comment 2
+      bar: baz
+
+queries:
+  - query: [foo, 0, bar]
+    expected: "      bar: baz"
+
+  - query: [multiple, 0, bar]
+    expected: "      bar: baz"


### PR DESCRIPTION
This allows `yamlpath` to handle patterns like the following:

```yaml
foo:
  - # surprise!
    bar: baz
```

i.e. where there's a `comment` node interceding the list element and its body.

See https://github.com/woodruffw/zizmor/issues/659.